### PR TITLE
test/AllBeanTest생성

### DIFF
--- a/src/main/java/youngHan/core/annotation/MainDiscountPolicy.java
+++ b/src/main/java/youngHan/core/annotation/MainDiscountPolicy.java
@@ -1,0 +1,13 @@
+package youngHan.core.annotation;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Qualifier("mainDiscountPolicy")
+public @interface MainDiscountPolicy {
+}

--- a/src/main/java/youngHan/core/discount/RateDiscountPolicy.java
+++ b/src/main/java/youngHan/core/discount/RateDiscountPolicy.java
@@ -1,13 +1,13 @@
 package youngHan.core.discount;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
+import youngHan.core.annotation.MainDiscountPolicy;
 import youngHan.core.member.Grade;
 import youngHan.core.member.Member;
 
 @Component
-@Qualifier("mainDiscountPolicy")
+@MainDiscountPolicy
 //@Primary 를 사용하면 의존 주입시 우선순위를 가지게 되지만 Qualifier 보다는 우선순위가 낮다.
 public class RateDiscountPolicy implements DiscountPolicy {
 

--- a/src/main/java/youngHan/core/order/OrderServiceImpl.java
+++ b/src/main/java/youngHan/core/order/OrderServiceImpl.java
@@ -3,6 +3,7 @@ package youngHan.core.order;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+import youngHan.core.annotation.MainDiscountPolicy;
 import youngHan.core.discount.DiscountPolicy;
 import youngHan.core.member.Member;
 import youngHan.core.member.MemberRepository;
@@ -14,7 +15,7 @@ public class OrderServiceImpl implements OrderService {
     private final DiscountPolicy discountPolicy;
 
     @Autowired
-    public OrderServiceImpl(MemberRepository memberRepository, @Qualifier("mainDiscountPolicy") DiscountPolicy discountPolicy) {
+    public OrderServiceImpl(MemberRepository memberRepository, @MainDiscountPolicy DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;
     }

--- a/src/test/java/youngHan/core/allbean/AllBeanTest.java
+++ b/src/test/java/youngHan/core/allbean/AllBeanTest.java
@@ -1,0 +1,53 @@
+package youngHan.core.allbean;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import youngHan.core.AutoAppConfig;
+import youngHan.core.discount.DiscountPolicy;
+import youngHan.core.member.Grade;
+import youngHan.core.member.Member;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class AllBeanTest {
+
+    @Test
+    void findAllBean() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class, DiscountService.class);
+
+        DiscountService discountService = ac.getBean(DiscountService.class);
+        Member member = new Member(1L, "memberA", Grade.VIP);
+        int discountPrice = discountService.discount(member, 10000, "fixDiscountPolicy");
+
+        assertThat(discountService).isInstanceOf(DiscountService.class);
+        assertThat(discountPrice).isEqualTo(1000);
+
+        int rateDiscountPrice = discountService.discount(member, 20000, "rateDiscountPolicy");
+        assertThat(discountService).isInstanceOf(DiscountService.class);
+        assertThat(discountPrice).isEqualTo(1000);
+    }
+
+    static class DiscountService {
+        private final Map<String, DiscountPolicy> policyMap;
+        private final List<DiscountPolicy> policyList;
+
+        @Autowired
+        public DiscountService(Map<String, DiscountPolicy> policyMap, List<DiscountPolicy> policyList) {
+            this.policyMap = policyMap;
+            this.policyList = policyList;
+            System.out.println("policyMap = " + policyMap);
+            System.out.println("policyList = " + policyList);
+        }
+
+        public int discount(Member member, int price, String discountCode) {
+            DiscountPolicy discountPolicy = policyMap.get(discountCode);
+            return discountPolicy.discount(member, price);
+        }
+    }
+
+}


### PR DESCRIPTION
📜 작업 내용

- [x] DiscountPolicy빈을 조회할 때 @Component로 인해 여러개의 빈이 조회됐을 경우 충돌을 해결하기 하기 위해
@Qualifier를 사용하게끔 수정하였음.
- [x] AllBeanTest를 이용하여 다형성을 활용해야 하는 경우 수동으로 빈을 등록하는 방법에 대한 테스트 생성

🙋 공유할 사항
@Primary 를 사용하면 의존 주입시 우선순위를 가지게 되지만 Qualifier 보다는 우선순위가 낮다.
기술 지원 객체나 특정 비즈니스 로직은 추후에 다른 개발자가 이해하기 쉽게 같은 패키지에 정리하거나  @Autowired가 아닌 수동으로 등록하는 것이 바람직 할 수도 있으므로 자동과 수동의 기준을 고려하여 설계할 것.